### PR TITLE
feat: Implement public project visibility system

### DIFF
--- a/cospace/app/Http/Controllers/Project/ProjectController.php
+++ b/cospace/app/Http/Controllers/Project/ProjectController.php
@@ -17,9 +17,12 @@ use Illuminate\Http\RedirectResponse;
 use App\Http\Controllers\Controller;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class ProjectController extends Controller
 {
+    use AuthorizesRequests;
+    
     protected \GuzzleHttp\Client $httpClient;
 
     public function __construct(
@@ -56,6 +59,7 @@ class ProjectController extends Controller
             'description' => 'nullable|string',
             'gif_url' => 'nullable|url',
             'repo_url' => 'nullable|url',
+            'is_public' => 'nullable|boolean',
         ]);
 
         // Validate gif_url is a valid image URL (skip validation for empty or placeholder URLs)
@@ -82,9 +86,13 @@ class ProjectController extends Controller
         return redirect()->route('projects.show', ['id' => $project->id])->with('message', 'Project created successfully!');
     }
 
-    public function show(int $id): Response
+    public function show(Request $request, int $id): Response
     {
         $project = $this->projectService->show($id);
+        
+        // Authorize the user can view this project
+        $this->authorize('view', $project);
+        
         return Inertia::render('Project/Show', [
             'project' => $project,
             'flash' => [
@@ -106,6 +114,7 @@ class ProjectController extends Controller
             'description' => 'nullable|string',
             'gif_url' => 'nullable|url',
             'repo_url' => 'nullable|url',
+            'is_public' => 'nullable|boolean',
         ]);
 
         // Validate gif_url is a valid image URL (skip validation for empty or placeholder URLs)

--- a/cospace/app/Models/Project.php
+++ b/cospace/app/Models/Project.php
@@ -16,6 +16,7 @@ class Project extends Model
         'description',
         'gif_url',
         'repo_url',
+        'is_public',
     ];
 
     public function user(): BelongsTo

--- a/cospace/app/Policies/ProjectPolicy.php
+++ b/cospace/app/Policies/ProjectPolicy.php
@@ -7,6 +7,17 @@ use App\Models\User;
 
 class ProjectPolicy
 {
+    public function view(?User $user, Project $project): bool
+    {
+        // Allow access if project is public
+        if ($project->is_public) {
+            return true;
+        }
+        
+        // Allow access if user is authenticated and owns the project
+        return $user && $user->id === $project->user_id;
+    }
+
     public function update(User $user, Project $project): bool
     {
         return $user->id === $project->user_id;

--- a/cospace/database/migrations/2025_08_09_061451_create_projects_table.php
+++ b/cospace/database/migrations/2025_08_09_061451_create_projects_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->text('description')->nullable();
             $table->string('gif_url')->nullable();
             $table->string('repo_url')->nullable();
+            $table->boolean('is_public')->default(false);
             $table->timestamps();
         });
     }

--- a/cospace/resources/js/pages/Project/Create.tsx
+++ b/cospace/resources/js/pages/Project/Create.tsx
@@ -10,12 +10,21 @@ import { Label } from '@/components/ui/label';
 import { Save, X, Eye, EyeOff } from 'lucide-react';
 import { getImageUrl, isGoogleDriveUrl } from '@/lib/google-drive-utils';
 
+
+
 export default function Create() {
-    const { data, setData, post, processing, errors } = useForm({
+    const { data, setData, post, processing, errors } = useForm<{
+        title: string;
+        description: string;
+        gif_url: string;
+        repo_url: string;
+        is_public: boolean;
+    }>({
         title: '',
         description: '',
         gif_url: '',
         repo_url: '',
+        is_public: false,
     });
 
     const [clientErrors, setClientErrors] = React.useState<{
@@ -187,6 +196,28 @@ export default function Create() {
                                     />
                                     {clientErrors.repo_url && <div className="text-destructive text-sm mt-1">{clientErrors.repo_url}</div>}
                                     {errors.repo_url && <div className="text-destructive text-sm mt-1">{errors.repo_url}</div>}
+                                </div>
+
+                                <div className="space-y-2 p-4 border rounded-lg bg-muted/30">
+                                    <div className="flex items-center gap-3">
+                                        <input
+                                            type="checkbox"
+                                            id="is_public"
+                                            checked={data.is_public}
+                                            onChange={(e) => setData('is_public', Boolean(e.target.checked))}
+                                            className="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                        />
+                                        <Label htmlFor="is_public" className="cursor-pointer text-base font-medium">
+                                            {data.is_public ? 'Make project private' : 'Make project public'}
+                                        </Label>
+                                    </div>
+                                    <p className="text-sm text-muted-foreground ml-8">
+                                        {data.is_public 
+                                            ? 'Public projects can be viewed by anyone, even without an account.'
+                                            : 'Private projects can only be viewed by you.'
+                                        }
+                                    </p>
+                                    {errors.is_public && <div className="text-destructive text-sm mt-1 ml-8">{errors.is_public}</div>}
                                 </div>
                             </CardContent>
                             <CardFooter className="flex justify-end gap-2">

--- a/cospace/resources/js/pages/Project/Edit.tsx
+++ b/cospace/resources/js/pages/Project/Edit.tsx
@@ -16,6 +16,7 @@ interface Project {
     description: string;
     gif_url?: string;
     repo_url?: string;
+    is_public: boolean;
 }
 
 interface EditPageProps {
@@ -28,6 +29,7 @@ export default function Edit({ project }: EditPageProps) {
         description: project.description || '',
         gif_url: project.gif_url || '',
         repo_url: project.repo_url || '',
+        is_public: project.is_public || false,
     });
 
     const [clientErrors, setClientErrors] = React.useState<{
@@ -200,6 +202,28 @@ export default function Edit({ project }: EditPageProps) {
                                     />
                                     {clientErrors.repo_url && <div className="text-destructive text-sm mt-1">{clientErrors.repo_url}</div>}
                                     {errors.repo_url && <div className="text-destructive text-sm mt-1">{errors.repo_url}</div>}
+                                </div>
+
+                                <div className="space-y-2 p-4 border rounded-lg bg-muted/30">
+                                    <div className="flex items-center gap-3">
+                                        <input
+                                            type="checkbox"
+                                            id="is_public"
+                                            checked={data.is_public}
+                                            onChange={(e) => setData('is_public', Boolean(e.target.checked))}
+                                            className="h-5 w-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                        />
+                                        <Label htmlFor="is_public" className="cursor-pointer text-base font-medium">
+                                            {data.is_public ? 'Make project private' : 'Make project public'}
+                                        </Label>
+                                    </div>
+                                    <p className="text-sm text-muted-foreground ml-8">
+                                        {data.is_public 
+                                            ? 'Public projects can be viewed by anyone, even without an account.'
+                                            : 'Private projects can only be viewed by you.'
+                                        }
+                                    </p>
+                                    {errors.is_public && <div className="text-destructive text-sm mt-1 ml-8">{errors.is_public}</div>}
                                 </div>
                             </CardContent>
                             <CardFooter className="flex justify-end gap-2">

--- a/cospace/resources/js/pages/Project/Show.tsx
+++ b/cospace/resources/js/pages/Project/Show.tsx
@@ -12,6 +12,7 @@ interface Project {
     description: string;
     gif_url?: string;
     repo_url?: string;
+    is_public: boolean;
     created_at: string;
     updated_at: string;
 }
@@ -89,6 +90,16 @@ export default function Show({ project }: ShowPageProps) {
                                     <div className="flex flex-col">
                                         <span className="text-sm font-medium text-muted-foreground">Last Updated</span>
                                         <span>{new Date(project.updated_at).toLocaleDateString()}</span>
+                                    </div>
+                                    <div className="flex flex-col">
+                                        <span className="text-sm font-medium text-muted-foreground">Visibility</span>
+                                        <span className={`inline-flex items-center justify-center my-2.5 px-1.5 py-2.5 rounded-full text-sm font-medium ${
+                                            project.is_public 
+                                                ? 'bg-green-100 text-green-800' 
+                                                : 'bg-gray-100 text-gray-800'
+                                        }`}>
+                                            {project.is_public ? 'Public' : 'Private'}
+                                        </span>
                                     </div>
                                     {project.repo_url && (
                                         <Button asChild variant="outline">

--- a/cospace/routes/project/web.php
+++ b/cospace/routes/project/web.php
@@ -3,15 +3,18 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Project\ProjectController;
 
-Route::middleware(['auth'])
-    ->prefix('projects')
+Route::prefix('projects')
     ->name('projects.')
     ->group(function () {
-        Route::get('/', [ProjectController::class, 'index'])->name('index');
-        Route::get('/create', [ProjectController::class, 'create'])->name('create');
-        Route::post('/', [ProjectController::class, 'store'])->name('store');
+        Route::middleware(['auth'])->group(function () {
+            Route::get('/', [ProjectController::class, 'index'])->name('index');
+            Route::get('/create', [ProjectController::class, 'create'])->name('create');
+            Route::post('/', [ProjectController::class, 'store'])->name('store');
+            Route::get('/{id}/edit', [ProjectController::class, 'edit'])->name('edit');
+            Route::put('/{id}', [ProjectController::class, 'update'])->name('update');
+            Route::delete('/{id}', [ProjectController::class, 'destroy'])->name('destroy');
+        });
+        
+        // Show route is accessible without authentication (authorization handled in controller)
         Route::get('/{id}', [ProjectController::class, 'show'])->name('show');
-        Route::get('/{id}/edit', [ProjectController::class, 'edit'])->name('edit');
-        Route::put('/{id}', [ProjectController::class, 'update'])->name('update');
-        Route::delete('/{id}', [ProjectController::class, 'destroy'])->name('destroy');
     });

--- a/cospace/src/Project/Entities/ProjectDTO.php
+++ b/cospace/src/Project/Entities/ProjectDTO.php
@@ -18,6 +18,7 @@ class ProjectDTO
         public readonly ?string $description = null,
         public readonly ?string $gif_url = null,
         public readonly ?string $repo_url = null,
+        public readonly bool $is_public = false,
     ) {}
 
     public static function fromArray(array $data): self
@@ -28,6 +29,7 @@ class ProjectDTO
             description: $data['description'] ?? null,
             gif_url: $data['gif_url'] ?? null,
             repo_url: $data['repo_url'] ?? null,
+            is_public: $data['is_public'] ?? false,
         );
     }
 
@@ -39,6 +41,7 @@ class ProjectDTO
             'description' => $this->description,
             'gif_url' => $this->gif_url,
             'repo_url' => $this->repo_url,
+            'is_public' => $this->is_public,
         ];
     }
 }

--- a/cospace/tests/Feature/ProjectVisibilityTest.php
+++ b/cospace/tests/Feature/ProjectVisibilityTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use App\Models\User;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProjectVisibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a mock HTTP client that simulates successful responses
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json']), // GitHub repo validation
+            new Response(200, ['Content-Type' => 'image/gif']),       // Image validation
+        ]);
+        
+        $handlerStack = HandlerStack::create($mock);
+        $mockClient = new GuzzleClient(['handler' => $handlerStack]);
+        
+        // Bind the mock client to the container
+        $this->app->instance(GuzzleClient::class, $mockClient);
+    }
+
+    public function test_public_project_can_be_viewed_by_anyone(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'user_id' => $user->id,
+            'is_public' => true,
+        ]);
+
+        // Unauthenticated user can view public project
+        $response = $this->get(route('projects.show', $project));
+        $response->assertOk();
+        $response->assertSee($project->title);
+
+        // Different authenticated user can view public project
+        $otherUser = User::factory()->create();
+        $response = $this->actingAs($otherUser)->get(route('projects.show', $project));
+        $response->assertOk();
+        $response->assertSee($project->title);
+    }
+
+    public function test_private_project_cannot_be_viewed_by_others(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'user_id' => $user->id,
+            'is_public' => false,
+        ]);
+
+        // Unauthenticated user cannot view private project
+        $response = $this->get(route('projects.show', $project));
+        $response->assertForbidden();
+
+        // Different authenticated user cannot view private project
+        $otherUser = User::factory()->create();
+        $response = $this->actingAs($otherUser)->get(route('projects.show', $project));
+        $response->assertForbidden();
+
+        // Owner can view private project
+        $response = $this->actingAs($user)->get(route('projects.show', $project));
+        $response->assertOk();
+        $response->assertSee($project->title);
+    }
+
+    public function test_owner_can_toggle_project_visibility(): void
+    {
+        $user = User::factory()->create();
+        $project = Project::factory()->create([
+            'user_id' => $user->id,
+            'is_public' => false,
+        ]);
+
+        // Make project public
+        $response = $this->actingAs($user)->put(route('projects.update', $project), [
+            'title' => $project->title,
+            'description' => $project->description,
+            'is_public' => true,
+        ]);
+
+        $response->assertRedirect(route('projects.show', $project));
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'is_public' => true,
+        ]);
+
+        // Make project private again
+        $response = $this->actingAs($user)->put(route('projects.update', $project), [
+            'title' => $project->title,
+            'description' => $project->description,
+            'is_public' => false,
+        ]);
+
+        $response->assertRedirect(route('projects.show', $project));
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'is_public' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
 Added public/private project functionality with is_public field, updated policies and routes for public access.
 Enhanced create/edit forms with dynamic visibility toggle and improved styling.
 Added visibility indicator badge on project show page. Included comprehensive tests for access control and toggle functionality.
 Maintained existing URL validation for images and GitHub repositories